### PR TITLE
fix: agent searching for itself in browseAgent

### DIFF
--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -175,7 +175,7 @@ class AcpClient {
   }
 
   async browseAgent(keyword: string, cluster?: string) {
-    let url = `${this.acpUrl}/api/agents?search=${keyword}&filters[walletAddress][$neq]=${this.acpContractClient.walletAddress}`;
+    let url = `${this.acpUrl}/api/agents?search=${keyword}&filters[walletAddress][$notIn]=${this.acpContractClient.walletAddress}`;
     if (cluster) {
       url += `&filters[cluster]=${cluster}`;
     }


### PR DESCRIPTION
- noticed while testing that $neq does not work properly; the agent can search for itself (this led to a job where a buyer initated job with itself - see screenshot below)
- current plugin also uses $notIn: https://github.com/game-by-virtuals/game-node/blob/feat/acp-plugin/plugins/acpPlugin/src/acpClient.ts#L41
![image](https://github.com/user-attachments/assets/56c7dce6-785e-4a1e-93d6-07b59bce6c37)
