### PR TITLE
Fix ESM and CJS module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,22 @@
 {
   "name": "@virtuals-protocol/acp-node",
   "version": "0.3.0-beta.17",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "scripts": {
     "test": "jest",
     "test:unit": "jest test/unit test/component",
@@ -25,6 +38,7 @@
     "jest": "^30.2.0",
     "jest-junit": "^16.0.0",
     "ts-jest": "^29.4.5",
+    "tsup": "^8.5.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {
@@ -35,7 +49,6 @@
     "ajv": "^8.17.1",
     "axios": "^1.13.2",
     "socket.io-client": "^4.8.1",
-    "tsup": "^8.5.0",
     "viem": "^2.28.2"
   },
   "files": [


### PR DESCRIPTION
What was wrong:
- Missing exports field - Modern Node.js and bundlers couldn't properly resolve the package
- No type field - Caused ambiguity about whether this is an ESM or CJS package
- tsup in main dependencies - Build tool was being installed in production
- Inconsistent file extensions - Mixed .mjs and .js naming

What was fixed:
- Added exports field for proper module resolution
- Set "type": "module" to clarify this is an ESM package
- Moved tsup to devDependencies
- Standardized output to .js (ESM) and .cjs (CommonJS)

Result:
Package now properly supports both import and require() with modern best practices and without issues cause earlier (constructor in types not detected, forcing client to use CommonJS)