### PR TITLE
feat: add txn hash from handle user ops return

### DIFF
--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -375,12 +375,12 @@ class AcpClient {
             isX402Job
           );
 
-    const txHash = await this.acpContractClient.handleOperation([
+    const { userOpHash } = await this.acpContractClient.handleOperation([
       createJobPayload,
     ]);
 
     const jobId = await this.acpContractClient.getJobId(
-      txHash,
+      userOpHash,
       this.walletAddress,
       providerAddress
     );

--- a/src/acpJobOffering.ts
+++ b/src/acpJobOffering.ts
@@ -107,12 +107,12 @@ class AcpJobOffering {
       );
     }
 
-    const createJobTxnHash = await this.acpContractClient.handleOperation([
+    const { userOpHash }  = await this.acpContractClient.handleOperation([
       createJobPayload,
     ]);
 
     const jobId = await this.acpContractClient.getJobId(
-      createJobTxnHash,
+      userOpHash,
       this.acpContractClient.walletAddress,
       this.providerAddress
     );

--- a/src/contractClients/acpContractClient.ts
+++ b/src/contractClients/acpContractClient.ts
@@ -110,7 +110,7 @@ class AcpContractClient extends BaseAcpContractClient {
     return finalMaxFeePerGas;
   }
 
-  async handleOperation(operations: OperationPayload[]) {
+  async handleOperation(operations: OperationPayload[]): Promise<{ userOpHash: Address , txnHash: Address }> {
     const payload: any = {
       uo: operations.map((op) => ({
         target: op.contractAddress,
@@ -137,11 +137,11 @@ class AcpContractClient extends BaseAcpContractClient {
 
         const { hash } = await this.sessionKeyClient.sendUserOperation(payload);
 
-        await this.sessionKeyClient.waitForUserOperationTransaction({
+        const txnHash = await this.sessionKeyClient.waitForUserOperationTransaction({
           hash,
         });
 
-        return hash;
+        return { userOpHash: hash, txnHash };
       } catch (error) {
         retries -= 1;
         if (retries === 0) {
@@ -157,11 +157,11 @@ class AcpContractClient extends BaseAcpContractClient {
   }
 
   async getJobId(
-    hash: Address,
+    createJobUserOpHash: Address,
     clientAddress: Address,
     providerAddress: Address
   ) {
-    const result = await this.sessionKeyClient.getUserOperationReceipt(hash);
+    const result = await this.sessionKeyClient.getUserOperationReceipt(createJobUserOpHash);
 
     if (!result) {
       throw new AcpError("Failed to get user operation receipt");

--- a/src/contractClients/baseAcpContractClient.ts
+++ b/src/contractClients/baseAcpContractClient.ts
@@ -89,10 +89,10 @@ abstract class BaseAcpContractClient {
     });
   }
 
-  abstract handleOperation(operations: OperationPayload[]): Promise<Address>;
+  abstract handleOperation(operations: OperationPayload[]): Promise<{ userOpHash: Address , txnHash: Address }>;
 
   abstract getJobId(
-    hash: Address,
+    createJobUserOpHash: Address,
     clientAddress: Address,
     providerAddress: Address
   ): Promise<number>;


### PR DESCRIPTION
to return txn hash from handle user ops, already in for python but devs have no trace of txn after ops in node before the change

the change return `userOpHash` & `txnHash` in an object as the following example:
```
{
  userOpHash: '0xb612ebf1a4211282d1411c7c2be1f55b32bd11a7d7fb7cc0a2c56f06732b49bf',
  txnHash: '0x0a9b7461299632ea0953f11624e28cdddbb3308dfd6d5abac65dee5246efd469'
}
```

tested and verified locally.