### PR TITLE
fix: fix floating point conversion

### DIFF
--- a/src/acpJob.ts
+++ b/src/acpJob.ts
@@ -167,7 +167,7 @@ class AcpJob {
         amount.amount,
         recipient,
         this.priceType === PriceType.PERCENTAGE
-          ? BigInt(this.priceValue * 10000) // convert to basis points
+          ? BigInt(Math.round(this.priceValue * 10000)) // convert to basis points
           : feeAmount.amount,
         this.priceType === PriceType.PERCENTAGE
           ? FeeType.PERCENTAGE_FEE


### PR DESCRIPTION
to cater for case where
this.priceValue = 0.0003
this.priceValue * 10000 = 2.9999999999999996

common js floating point conversion issue