### PR TITLE
fix: remove matrix version for ci report

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,5 +46,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: test-results-${{ matrix.node-version }}
+          name: test-results
           path: junit.xml


### PR DESCRIPTION
prev testing included node 18, which we needed matrix version to view 2 separate reports, since now we're only testing node 20, test-report.yml only should look for one file