### PR TITLE
fix: add ajv address format validation and chainId guard in deliverPayable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@account-kit/smart-contracts": "^4.73.0",
         "@virtuals-protocol/acp-node": "^0.3.0-beta.10",
         "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.13.2",
         "jwt-decode": "^4.0.0",
         "socket.io-client": "^4.8.1",
@@ -4840,6 +4841,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/alchemy-sdk": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@account-kit/smart-contracts": "^4.73.0",
     "@virtuals-protocol/acp-node": "^0.3.0-beta.10",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.13.2",
     "jwt-decode": "^4.0.0",
     "socket.io-client": "^4.8.1",

--- a/src/acpJob.ts
+++ b/src/acpJob.ts
@@ -458,7 +458,10 @@ class AcpJob {
     expiredAt: Date = new Date(Date.now() + 1000 * 60 * 5) // 5 minutes
   ) {
     // If payable chain belongs to non ACP native chain, we route to transfer service
-    if (amount.fare.chainId !== this.acpContractClient.config.chain.id) {
+    if (
+      amount.fare.chainId &&
+      amount.fare.chainId !== this.acpContractClient.config.chain.id
+    ) {
       return await this.deliverCrossChainPayable(
         this.clientAddress,
         preparePayload(deliverable),

--- a/src/acpJobOffering.ts
+++ b/src/acpJobOffering.ts
@@ -1,6 +1,7 @@
 import { Address, zeroAddress } from "viem";
 import AcpClient from "./acpClient";
 import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { FareAmount } from "./acpFare";
 import AcpError from "./acpError";
 import BaseAcpContractClient, {
@@ -35,6 +36,8 @@ class AcpJobOffering {
     public deliverable?: Object | string
   ) {
     this.ajv = new Ajv({ allErrors: true });
+    addFormats(this.ajv);
+    this.ajv.addFormat("address", /^0x[a-fA-F0-9]{40}$/);
   }
 
   async initiateJob(


### PR DESCRIPTION
- Register custom Ethereum `address` format with AJV via `ajv-formats` to fix `unknown format "address"` crash in `initiateJob()`
- Add truthy guard for `fare.chainId` in `deliverPayable()` to prevent incorrect cross-chain routing when chainId is undefined
