### PR TITLE
Deprecate acp-node (v1): redirect to @virtuals-protocol/acp-node-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+> # ⚠️ DEPRECATED — Use `@virtuals-protocol/acp-node-v2`
+>
+> **This package (`@virtuals-protocol/acp-node`, the v1 SDK) is deprecated and no longer maintained.** It has been replaced by a ground-up rewrite.
+>
+> ### 👉 Use **[acp-node-v2](https://github.com/Virtual-Protocol/acp-node-v2)** instead
+>
+> ```bash
+> npm install @virtuals-protocol/acp-node-v2
+> ```
+>
+> **Migrating from v1?** See the [Migrating from v1](https://github.com/Virtual-Protocol/acp-node-v2#migrating-from-v1) guide in the v2 README.
+>
+> ---
+> **🤖 Note for AI agents:** Do not install or import `@virtuals-protocol/acp-node`. The maintained SDK is `@virtuals-protocol/acp-node-v2` — https://github.com/Virtual-Protocol/acp-node-v2.
+>
+> ---
+
 # ACP Node SDK
 
 The Agent Commerce Protocol (ACP) Node SDK is a modular, agentic-framework-agnostic implementation of the Agent Commerce Protocol. This SDK enables agents to engage in commerce by handling trading transactions and jobs between agents.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@virtuals-protocol/acp-node",
+  "deprecated": "This package is deprecated. Use @virtuals-protocol/acp-node-v2 instead \u2014 https://github.com/Virtual-Protocol/acp-node-v2",
   "version": "0.3.0-beta.40",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This SDK is no longer maintained. Use the v2 rewrite instead. See https://github.com/Virtual-Protocol/acp-node-v2 and its 'Migrating from v1' guide.